### PR TITLE
Fix forum search index rebuild

### DIFF
--- a/src/Commands/CreateSearchIndexes.php
+++ b/src/Commands/CreateSearchIndexes.php
@@ -14,7 +14,7 @@ class CreateSearchIndexes extends Command
      *
      * @var string
      */
-    protected $signature = 'forums:rebuildSearchIndexes';
+    protected $signature = 'forums:rebuildSearchIndexes {--fresh}';
 
     /**
      * The console command description.
@@ -43,7 +43,7 @@ class CreateSearchIndexes extends Command
                 config()->set('railforums.brand', $brand);
 
                 $this->info('Starting forums search indexes for: ' . $brand);
-                $searchIndexRepository->createSearchIndexes($brand);
+                $searchIndexRepository->rebuildSearchIndexes($this->option('fresh'));
                 $this->info('Finished forums search indexes for: ' . $brand);
             }
         }

--- a/src/Commands/ProfileSearchIndexes.php
+++ b/src/Commands/ProfileSearchIndexes.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Railroad\Railforums\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Railroad\Railforums\Repositories\SearchIndexRepository;
+use Railroad\Railforums\Services\ConfigService;
+
+class ProfileSearchIndexes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'forums:profileSearchIndexes 
+                            {brand=drumeo : The brand to use}
+                            {runs=5 : The number of times to run the query}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Perform a simple query on search indexes multiple times to profile the response time';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(SearchIndexRepository $searchIndexRepository)
+    {
+        $brand = $this->argument('brand');
+        if (!array_key_exists($brand, config('railforums.brand_database_connection_names'))) {
+            $this->error("$brand is not a valid brand");
+            return;
+        }
+
+        $timeStart = microtime(true);
+        $this->info("Processing $this->name");
+        $this->info('Starting ' . Carbon::now()->toDateTimeString());
+
+        $railforumsConnectionName = config('railforums.brand_database_connection_names')[$brand];
+        ConfigService::$databaseConnectionName = $railforumsConnectionName;
+        config()->set('railforums.database_connection', $railforumsConnectionName);
+        config()->set('railforums.database_connection_name', $railforumsConnectionName);
+        config()->set('railforums.brand', $brand);
+
+        $runs = collect();
+        $runsCount = $this->argument('runs');
+
+        for ($run = 1; $run <= $runsCount; $run++ ) {
+            $runTimeStart = microtime(true);
+            $this->info('Starting search for run ' . $run);
+            $searchIndexRepository->search(
+                "say hello",
+                1,
+                10,
+                "score"
+            );
+
+            $runTime = number_format(microtime(true) - $runTimeStart, 4);
+            $runs->push($runTime);
+            $this->info("Finished search for run $run in $runTime s");
+        }
+
+        $this->info('End ' . Carbon::now()->toDateTimeString());
+
+        $diff = microtime(true) - $timeStart;
+        $sec = intval($diff);
+        $this->info("Finished $this->name ($sec s)");
+
+        $runs = $runs->sort();
+        $this->newLine();
+        $this->info("Fastest run: {$runs->first()}");
+        $this->info("Slowest run: {$runs->last()}");
+        $this->info("Median run: {$runs->median()}");
+    }
+}

--- a/src/Decorators/PostUserDecorator.php
+++ b/src/Decorators/PostUserDecorator.php
@@ -57,11 +57,11 @@ class PostUserDecorator extends ModeDecoratorBase implements DecoratorInterface
             foreach ($posts as $postIndex => $post) {
                 $posts[$postIndex]['published_on_formatted'] =
                     Carbon::parse($post['published_on'])
-                        ->timezone($currentUser->getTimezone())
+                        ->timezone($currentUser?->getTimezone() ?? 'America/Los_Angeles')
                         ->format('M j, Y') .
                     ' AT ' .
                     Carbon::parse($post['published_on'])
-                        ->timezone($currentUser->getTimezone())
+                        ->timezone($currentUser?->getTimezone() ?? 'America/Los_Angeles')
                         ->format('g:i A');
                 $posts[$postIndex]['published_on_formatted'] =  $posts[$postIndex]['created_at_diff'] = Carbon::parse($posts[$postIndex]['created_at'])
                                         ->diffForHumans();
@@ -126,11 +126,11 @@ class PostUserDecorator extends ModeDecoratorBase implements DecoratorInterface
 
             $posts[$postIndex]['published_on_formatted'] =
                 Carbon::parse($post['published_on'])
-                    ->timezone($currentUser->getTimezone())
+                    ->timezone($currentUser?->getTimezone() ?? 'America/Los_Angeles')
                     ->format('M j, Y') .
                 ' AT ' .
                 Carbon::parse($post['published_on'])
-                    ->timezone($currentUser->getTimezone())
+                    ->timezone($currentUser?->getTimezone() ?? 'America/Los_Angeles')
                     ->format('g:i A');
 
             $posts[$postIndex]['is_liked_by_viewer'] =

--- a/src/Providers/ForumServiceProvider.php
+++ b/src/Providers/ForumServiceProvider.php
@@ -5,6 +5,7 @@ namespace Railroad\Railforums\Providers;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Railroad\Railforums\Commands\CreateSearchIndexes;
 use Railroad\Railforums\Commands\PopulateLastPostOnForums;
+use Railroad\Railforums\Commands\ProfileSearchIndexes;
 use Railroad\Railforums\Decorators\PostUserDecorator;
 use Railroad\Railforums\Decorators\ThreadUserDecorator;
 use Railroad\Railforums\EventListeners\ThreadEventListener;
@@ -53,7 +54,8 @@ class ForumServiceProvider extends EventServiceProvider
 
         $this->commands([
             CreateSearchIndexes::class,
-            PopulateLastPostOnForums::class
+            PopulateLastPostOnForums::class,
+            ProfileSearchIndexes::class
         ]);
 
         parent::boot();

--- a/src/Repositories/SearchIndexRepository.php
+++ b/src/Repositories/SearchIndexRepository.php
@@ -208,16 +208,42 @@ SQL;
     }
 
     /**
-     * Truncates search indexes table
-     * Calls post and thread repositories createSearchIndexes method
-     * Calls SQL optimize command
+     * Rebuild the search indexes table
+     * by finding all posts and threads updated since the last rebuild,
+     * and updating or creating entries in the table, with the option to
+     * truncate the table and rebuild it from scratch
      *
+     * @param bool $truncate whether to truncate the tables first, or not
      * @return void
      */
-    public function createSearchIndexes(): void
+    public function rebuildSearchIndexes(bool $truncate = false): void
     {
         DB::disableQueryLog();
 
+        if ($truncate) {
+            $this->deleteOldIndexes();
+            $lastUpdate = null;
+        } else {
+            $lastUpdate = $this->getLastDateTimeSearchIndexesRebuilt();
+        }
+
+        $updateAt = Carbon::now()->toDateTimeString();
+
+        $postsQuery = $this->getQueryForPostSearchIndexValues($lastUpdate);
+        $threadsQuery = $this->getQueryForThreadSearchIndexValues($lastUpdate);
+        $users = $this->getPostAuthors($postsQuery);
+
+        $this->updatePostSearchIndexes($postsQuery, $users, $updateAt);
+        $this->updateThreadSearchIndexes($threadsQuery, $users, $updateAt);
+    }
+
+    /**
+     * Get the datetime when the Search Index table was last rebuilt
+     *
+     * @return string
+     */
+    protected function getLastDateTimeSearchIndexesRebuilt(): string
+    {
         // figure out when the last update was done, so we can scope the query
         $lastUpdate = DB::connection(ConfigService::$databaseConnectionName)
             ->table(ConfigService::$tableSearchIndexes)
@@ -231,51 +257,79 @@ SQL;
             $lastUpdate = Carbon::createFromTimestamp(0)->toDateTimeString();
         }
 
-        $postsQuery = $this->getQueryForPostSearchIndexValues($lastUpdate);
+        return $lastUpdate;
+    }
 
-        $users = $this->getAuthors($postsQuery);
+    /**
+     * Build up the query to get the data required for Thread search index entries
+     *
+     * @param Carbon|string|null $lastUpdate
+     * @return ThreadRepository|CachedQuery
+     */
+    protected function getQueryForThreadSearchIndexValues(Carbon|string|null $lastUpdate): ThreadRepository|CachedQuery
+    {
+        return $this->threadRepository->newQuery()
+            ->from(ConfigService::$tableThreads)
+            ->select(ConfigService::$tableThreads . '.id',
+                ConfigService::$tableThreads . '.title',
+                ConfigService::$tableThreads . '.author_id',
+                ConfigService::$tableThreads . '.published_on'
+            )
+            ->whereNull(ConfigService::$tableThreads . '.deleted_at')
+            ->when(!is_null($lastUpdate), fn ($q) =>
+                $q->where(ConfigService::$tableThreads . ".updated_at", ">=", $lastUpdate)
+            )
+            ->orderBy(ConfigService::$tableThreads . '.id');
+    }
 
-        $now = Carbon::now()->toDateTimeString();
+    /**
+     * Build up the query to get the data required for Post search index entries
+     *
+     * @param Carbon|string|null $lastUpdate
+     * @return PostRepository|CachedQuery
+     */
+    protected function getQueryForPostSearchIndexValues(Carbon|string|null $lastUpdate): PostRepository|CachedQuery
+    {
+        return $this->postRepository->newQuery()
+            ->from(ConfigService::$tablePosts)
+            ->join(
+                ConfigService::$tableThreads,
+                ConfigService::$tablePosts . '.thread_id',
+                '=',
+                ConfigService::$tableThreads . '.id'
+            )
+            ->select(
+                ConfigService::$tablePosts . '.content',
+                ConfigService::$tablePosts . '.thread_id',
+                ConfigService::$tablePosts . '.author_id',
+                ConfigService::$tablePosts . '.id',
+                ConfigService::$tablePosts . '.published_on'
+            )
+            ->when(!is_null($lastUpdate), fn ($q) =>
+                $q->where(ConfigService::$tablePosts . ".updated_at", ">=", $lastUpdate)
+            )
+            ->whereNull(ConfigService::$tablePosts . '.deleted_at')
+            ->whereNull(ConfigService::$tableThreads . '.deleted_at')
+            ->whereIn(
+                ConfigService::$tablePosts . '.state',
+                ['published']
+            )
+            ->orderBy(ConfigService::$tablePosts . '.id');
+    }
 
-        $postsQuery->chunkById(
+    /**
+     * Update the search index table with entries for Threads
+     *
+     * @param PostRepository|CachedQuery $query
+     * @param User[] $users
+     * @param string $updateAt
+     * @return void
+     */
+    protected function updateThreadSearchIndexes(PostRepository|CachedQuery $query, array $users, string $updateAt): void
+    {
+        $query->chunkById(
             2000,
-            function (Collection $postsData) use ($now, $users) {
-                $searchIndexes = [];
-                foreach ($postsData as $postData) {
-                    $author = $users[$postData->author_id] ?? null;
-
-                    $searchIndexes[] = [
-                        'high_value' => substr(
-                            utf8_encode($this->postRepository->getFilteredPostContent($postData->content)),
-                            0,
-                            65535
-                        ),
-                        'low_value' => $author?->getDisplayName() ?? '',
-                        'thread_id' => $postData->thread_id,
-                        'post_id' => $postData->id,
-                        'created_at' => $now,
-                        'updated_at' => $now,
-                        'published_on' => $postData->published_on,
-                    ];
-                }
-
-                DB::connection(ConfigService::$databaseConnectionName)
-                    ->table(ConfigService::$tableSearchIndexes)
-                    ->upsert(
-                        $searchIndexes,
-                        ['thread_id', 'post_id']
-                    );
-                usleep(250000); //delay 250 ms to reduce load
-            },
-            ConfigService::$tablePosts . '.id',
-            'id'
-        );
-
-        $threadsQuery = $this->getQueryForThreadSearchIndexValues($lastUpdate);
-
-        $threadsQuery->chunkById(
-            2000,
-            function (Collection $threadsData) use ($now, $users) {
+            function (Collection $threadsData) use ($updateAt, $users) {
                 $searchIndexes = [];
                 foreach ($threadsData as $threadData) {
                     $author = $users[$threadData->author_id] ?? null;
@@ -283,8 +337,8 @@ SQL;
                         'medium_value' => $threadData->title,
                         'low_value' => $author ? $author->getDisplayName() : '',
                         'thread_id' => $threadData->id,
-                        'created_at' => $now,
-                        'updated_at' => $now,
+                        'created_at' => $updateAt,
+                        'updated_at' => $updateAt,
                         'published_on' => $threadData->published_on,
                     ];
                 }
@@ -310,69 +364,61 @@ SQL;
     }
 
     /**
-     * Build up the query to get the data required for Post search index entries
+     * Update the search index table with entries for Posts
      *
-     * @param Carbon|String $lastUpdate
-     * @return PostRepository|CachedQuery
+     * @param PostRepository|CachedQuery $query
+     * @param User[] $users
+     * @param string $updateAt
+     * @return void
      */
-    protected function getQueryForPostSearchIndexValues(Carbon|String $lastUpdate): PostRepository|CachedQuery
+    protected function updatePostSearchIndexes(PostRepository|CachedQuery $query, array $users, string $updateAt): void
     {
-        return $this->postRepository->newQuery()
-            ->from(ConfigService::$tablePosts)
-            ->join(
-                ConfigService::$tableThreads,
-                ConfigService::$tablePosts . '.thread_id',
-                '=',
-                ConfigService::$tableThreads . '.id'
-            )
-            ->select(
-                ConfigService::$tablePosts . '.content',
-                ConfigService::$tablePosts . '.thread_id',
-                ConfigService::$tablePosts . '.author_id',
-                ConfigService::$tablePosts . '.id',
-                ConfigService::$tablePosts . '.published_on'
-            )
-            ->where(ConfigService::$tablePosts . ".updated_at", ">=", $lastUpdate)
-            ->whereNull(ConfigService::$tablePosts . '.deleted_at')
-            ->whereNull(ConfigService::$tableThreads . '.deleted_at')
-            ->whereIn(
-                ConfigService::$tablePosts . '.state',
-                ['published']
-            )
-            ->orderBy(ConfigService::$tablePosts . '.id');
-    }
+        $query->chunkById(
+            2000,
+            function (Collection $postsData) use ($updateAt, $users) {
+                $searchIndexes = [];
+                foreach ($postsData as $postData) {
+                    $author = $users[$postData->author_id] ?? null;
 
-    /**
-     * Build up the query to get the data required for Thread search index entries
-     *
-     * @param Carbon|String $lastUpdate
-     * @return ThreadRepository|CachedQuery
-     */
-    protected function getQueryForThreadSearchIndexValues(Carbon|String $lastUpdate): ThreadRepository|CachedQuery
-    {
-        return $this->threadRepository->newQuery()
-            ->from(ConfigService::$tableThreads)
-            ->select(ConfigService::$tableThreads . '.id',
-                ConfigService::$tableThreads . '.title',
-                ConfigService::$tableThreads . '.author_id',
-                ConfigService::$tableThreads . '.published_on'
-            )
-            ->whereNull(ConfigService::$tableThreads . '.deleted_at')
-            ->where(ConfigService::$tableThreads . ".updated_at", ">=", $lastUpdate)
-            ->orderBy(ConfigService::$tableThreads . '.id');
+                    $searchIndexes[] = [
+                        'high_value' => substr(
+                            utf8_encode($this->postRepository->getFilteredPostContent($postData->content)),
+                            0,
+                            65535
+                        ),
+                        'low_value' => $author?->getDisplayName() ?? '',
+                        'thread_id' => $postData->thread_id,
+                        'post_id' => $postData->id,
+                        'created_at' => $updateAt,
+                        'updated_at' => $updateAt,
+                        'published_on' => $postData->published_on,
+                    ];
+                }
+
+                DB::connection(ConfigService::$databaseConnectionName)
+                    ->table(ConfigService::$tableSearchIndexes)
+                    ->upsert(
+                        $searchIndexes,
+                        ['thread_id', 'post_id']
+                    );
+                usleep(250000); //delay 250 ms to reduce load
+            },
+            ConfigService::$tablePosts . '.id',
+            'id'
+        );
     }
 
     /**
      * Get an array of the User models for all unique Post authors
      *
-     * @param CachedQuery $query
+     * @param PostRepository|CachedQuery $postsQuery
      * @return User[]
      */
-    protected function getAuthors(CachedQuery $query): array
+    protected function getPostAuthors(PostRepository|CachedQuery $postsQuery): array
     {
         $key = "author_id";
         $column = ConfigService::$tablePosts . ".$key";
-        $usersQuery = $query->cloneWithout(["orders"]);
+        $usersQuery = $postsQuery->cloneWithout(["orders"]);
 
         $userIds = $usersQuery
             ->select($column)

--- a/src/Repositories/SearchIndexRepository.php
+++ b/src/Repositories/SearchIndexRepository.php
@@ -226,6 +226,11 @@ SQL;
             ->limit(1)
             ->value("updated_at");
 
+        // safety in case of first run
+        if (is_null($lastUpdate)) {
+            $lastUpdate = Carbon::createFromTimestamp(0)->toDateTimeString();
+        }
+
         $postsQuery = $this->getQueryForPostSearchIndexValues($lastUpdate);
 
         $users = $this->getAuthors($postsQuery);


### PR DESCRIPTION
- Added a query scope to find the last time we ran the rebuild and only use posts and threads that were updated since then
- I found that the `upsert` on threads was failing because it used the (null) post_id as part of the unique constraint, and so it keeps inserting new entries every time. As an example, run `SELECT * FROM drumeo_laravel.forum_search_indexes WHERE thread_id = 15168;` on prod and you'll see 183 (or more) duplicates of the thread. To fix this, we now do an `updateOrInsert` so we can supply the null post_id criteria to find the match and update it
- I also split out finding the users and keeping them in memory, instead of performing extra queries within the chunks. It makes a bigger hit on memory, but saved nearly 20 seconds on the command's runtime (before my date constraints)
- I've also added a new command to run the SearchIndexRepository's search multiple times, in order to profile how long the search queries should take (which also required a small change to the PostUserDecorator to allow the search to function without a user). This was helpful for comparing the effectiveness of the change, and might be helpful again in the future.