### PR TITLE
Fix(BR-322): Service unavailable in forums notifications

### DIFF
--- a/src/Providers/ForumServiceProvider.php
+++ b/src/Providers/ForumServiceProvider.php
@@ -25,7 +25,7 @@ class ForumServiceProvider extends EventServiceProvider
             PostEventListener::class . '@onPostCreated',
         ],
         ThreadDeleted::class => [
-            ThreadEventListener::class.'onDeleted',
+            ThreadEventListener::class . '@onDeleted',
         ]
     ];
 


### PR DESCRIPTION
[BR-322](https://musora.atlassian.net/browse/BR-322)

Solarwind log:
`Sep 29 05:38:37 PM [18.190.164.73-1](https://my.na-01.cloud.solarwinds.com/226061846062446592/logs?q=host%3A%2218.190.164.73-1%22&focus=1909479944937996291&selected=1909479944937996291) [logger](https://my.na-01.cloud.solarwinds.com/226061846062446592/logs?q=program%3A%22logger%22&focus=1909479944937996291&selected=1909479944937996291) [2025-09-30 00:38:37] production.ERROR: Target class [Railroad\Railforums\EventListeners\ThreadEventListeneronDeleted] does not exist. {"userId":641052,"exception":"[object] (Illuminate\\Contracts\\Container\\BindingResolutionException(code: 0): Target class [Railroad\\Railforums\\EventListeners\\ThreadEventListeneronDeleted] does not exist. at /var/task/vendor/laravel/framework/src/Illuminate/Container/Container.php:961)`

This fixes the misnamed ThreadEventListener.