### PR TITLE
fix(BR-363): category metadata on thread move

### DIFF
--- a/src/EventListeners/ThreadEventListener.php
+++ b/src/EventListeners/ThreadEventListener.php
@@ -53,4 +53,48 @@ class ThreadEventListener
             'post_count' => $categoryThreadsCount,
         ]);
     }
+
+    /**
+     * Handle thread updated event - recalculate category metadata when thread is moved
+     *
+     * @param ThreadUpdated $event
+     */
+    public function onUpdated(ThreadUpdated $event)
+    {
+        $oldCategoryId = $event->getOldCategoryId();
+
+        // Only proceed if this was a category change
+        if (!$oldCategoryId) {
+            return;
+        }
+
+        // Get the updated thread to find new category
+        $thread = $this->threadRepository->read($event->getThreadId());
+        if (!$thread) {
+            return;
+        }
+
+        $newCategoryId = $thread->category_id;
+
+        // Double-check category actually changed (shouldn't happen but safety check)
+        if ($oldCategoryId == $newCategoryId) {
+            return;
+        }
+
+        // Update OLD category metadata
+        $oldCategoryLastPost = $this->categoryRepository->calculateLastPostId($oldCategoryId);
+        $oldCategoryThreadCount = $this->threadRepository->getThreadsCount([$oldCategoryId]);
+        $this->categoryRepository->update($oldCategoryId, [
+            'last_post_id' => $oldCategoryLastPost->post_id ?? null,
+            'post_count' => $oldCategoryThreadCount,
+        ]);
+
+        // Update NEW category metadata
+        $newCategoryLastPost = $this->categoryRepository->calculateLastPostId($newCategoryId);
+        $newCategoryThreadCount = $this->threadRepository->getThreadsCount([$newCategoryId]);
+        $this->categoryRepository->update($newCategoryId, [
+            'last_post_id' => $newCategoryLastPost->post_id ?? null,
+            'post_count' => $newCategoryThreadCount,
+        ]);
+    }
 }

--- a/src/EventListeners/ThreadEventListener.php
+++ b/src/EventListeners/ThreadEventListener.php
@@ -4,6 +4,7 @@ namespace Railroad\Railforums\EventListeners;
 
 use Railroad\Railforums\Events\ThreadCreated;
 use Railroad\Railforums\Events\ThreadDeleted;
+use Railroad\Railforums\Events\ThreadUpdated;
 use Railroad\Railforums\Repositories\CategoryRepository;
 use Railroad\Railforums\Repositories\ThreadFollowRepository;
 use Railroad\Railforums\Repositories\ThreadRepository;

--- a/src/Events/ThreadUpdated.php
+++ b/src/Events/ThreadUpdated.php
@@ -6,11 +6,14 @@ class ThreadUpdated extends EventBase
 {
     private $threadId;
 
-    public function __construct($threadId, $userId)
+    private $oldCategoryId;
+
+    public function __construct($threadId, $userId, $oldCategoryId = null)
     {
         parent::__construct($userId);
 
         $this->threadId = $threadId;
+        $this->oldCategoryId = $oldCategoryId;
     }
 
     /**
@@ -28,4 +31,13 @@ class ThreadUpdated extends EventBase
     {
         $this->threadId = $threadId;
     }
+
+    /**
+     * @return int|null $oldCategoryId
+     */
+    public function getOldCategoryId() {
+        return $this->oldCategoryId;
+    }
+
+
 }

--- a/src/Providers/ForumServiceProvider.php
+++ b/src/Providers/ForumServiceProvider.php
@@ -14,6 +14,7 @@ use Railroad\Railforums\Events\ThreadDeleted;
 use Railroad\Railforums\Services\ConfigService;
 use Railroad\Railforums\EventListeners\PostEventListener;
 use Railroad\Railforums\Events\PostDeleted;
+use Railroad\Railforums\Events\ThreadUpdated;
 
 class ForumServiceProvider extends EventServiceProvider
 {
@@ -26,6 +27,9 @@ class ForumServiceProvider extends EventServiceProvider
         ],
         ThreadDeleted::class => [
             ThreadEventListener::class . '@onDeleted',
+        ],
+        ThreadUpdated::class => [
+            ThreadEventListener::class . '@onUpdated',
         ]
     ];
 

--- a/src/Repositories/ThreadRepository.php
+++ b/src/Repositories/ThreadRepository.php
@@ -24,6 +24,8 @@ class ThreadRepository extends EventDispatchingRepository
 
     public static $onlyMine = false;
 
+    private $oldCategoryIdBeforeUpdate;
+
     private UserProviderInterface $userProvider;
 
     public function __construct(UserProviderInterface $userProvider)
@@ -47,9 +49,13 @@ class ThreadRepository extends EventDispatchingRepository
     {
         $id = is_object($entity) ? $entity->id : $entity;
 
-        return new ThreadUpdated(
-            $id, auth()->id()
-        );
+        // Pass the old category ID to the event if it was captured
+        $oldCategoryId = $this->oldCategoryIdBeforeUpdate;
+
+        // Reset the stored value
+        $this->oldCategoryIdBeforeUpdate = null;
+
+        return new ThreadUpdated($id, auth()->id(), $oldCategoryId);
     }
 
     public function getDestroyEvent($entity)
@@ -435,5 +441,26 @@ class ThreadRepository extends EventDispatchingRepository
             ->orderBy('p.published_on', 'desc')
             ->limit(1)
             ->first();
+    }
+
+    /**
+     * Override update to capture old category_id before update
+     *
+     * @param $id
+     * @param array|null $attributes
+     * @return mixed
+     */
+    public function update($id, $attributes = null)
+    {
+        $this->oldCategoryIdBeforeUpdate = null;
+
+        if (is_array($attributes) && isset($attributes['category_id'])) {
+            $existingThread = $this->baseRead($id);
+            if ($existingThread && $existingThread->category_id != $attributes['category_id']) {
+                $this->oldCategoryIdBeforeUpdate = $existingThread['category_id'];
+            }
+        }
+
+        return parent::update($id, $attributes);
     }
 }


### PR DESCRIPTION
[JIRA](https://musora.atlassian.net/browse/BR-363)

This adds some handling for updates so the category metadata (last_post_id, post_count) when threads are moved to different categories.